### PR TITLE
Add sonasky.app as community-trusted labeler

### DIFF
--- a/web/admin/composables/useBlueskyLabels.ts
+++ b/web/admin/composables/useBlueskyLabels.ts
@@ -22,6 +22,10 @@ const labelers: Array<Labeler> = [
     did: "did:plc:lcdcygpdeiittdmdeddxwt4w",
     name: "laelaps.fyi",
   },
+  {
+    did: "did:plc:2qawvcwumvgxmed6iy6pmt6l",
+    name: "sonasky.app"
+  }
 ];
 
 type Labeler = {


### PR DESCRIPTION
This adds `sonasky.app` to the list of labelers trusted by the community
that are considered for showing actor labels on the admin site.

If an account is labeled by sonasky, it's very likely that that account
is furry(-adjacent).

<img width="387" height="266" alt="image" src="https://github.com/user-attachments/assets/c44a6045-5370-418a-be65-dd34712bf0aa" />
