### PR TITLE
feat(no-release): add aimod.social labeler

### DIFF
--- a/web/admin/composables/useBlueskyLabels.ts
+++ b/web/admin/composables/useBlueskyLabels.ts
@@ -24,8 +24,12 @@ const labelers: Array<Labeler> = [
   },
   {
     did: "did:plc:2qawvcwumvgxmed6iy6pmt6l",
-    name: "sonasky.app"
-  }
+    name: "sonasky.app",
+  },
+  {
+    did: "did:plc:bpkpvmwpd3nr2ry4btt55ack",
+    name: "aimod.social",
+  },
 ];
 
 type Labeler = {


### PR DESCRIPTION
This adds the `aimod.social` labeler that flags suspected AI imagery to
the admin panel, so we have an additional indication to check an account
for AI images.

See https://query.aimod.social/docs.
